### PR TITLE
added the CV extraction endpoint with nuextract 

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ func main() {
 	r.Use(middleware.Logger())
 
 	r.GET("/health", handlers.Health)
+	r.POST("/extract", handlers.ExtractCV)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/internal/handlers/extract.go
+++ b/internal/handlers/extract.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+
+	"backend-api-skillforge/internal/nuextract"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ExtractCV traite l’upload d’un CV et renvoie le JSON NuExtract.
+func ExtractCV(c *gin.Context) {
+	file, _, err := c.Request.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file not provided"})
+		return
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot read file"})
+		return
+	}
+
+	client := nuextract.New()
+	result, err := client.Extract(data)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	// NuExtract retourne déjà du JSON → on le transmet tel quel.
+	c.Data(http.StatusOK, "application/json", result)
+}

--- a/internal/nuextract/client.go
+++ b/internal/nuextract/client.go
@@ -1,0 +1,47 @@
+package nuextract
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type Client struct {
+	projectID string
+	apiKey    string
+	http      *http.Client
+}
+
+func New() *Client {
+	return &Client{
+		projectID: os.Getenv("NUEXTRACT_PROJECT_ID"),
+		apiKey:    os.Getenv("NUEXTRACT_API_KEY"),
+		http:      &http.Client{},
+	}
+}
+
+// Extract envoie un fichier binaire (PDF) à NuExtract et renvoie la réponse brute.
+func (c *Client) Extract(file []byte) ([]byte, error) {
+	url := fmt.Sprintf("https://nuextract.ai/api/projects/%s/extract", c.projectID)
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(file))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("nuextract error %d: %s", resp.StatusCode, body)
+	}
+	return io.ReadAll(resp.Body)
+}


### PR DESCRIPTION
This PR adds a new /extract endpoint that handles PDF CV uploads, sends the file to the NuExtract API, and returns a structured JSON with candidate information (with field names matching those expected on the frontend).