### PR TITLE
add open ai llm

### DIFF
--- a/internal/nuextract/client.go
+++ b/internal/nuextract/client.go
@@ -1,47 +1,109 @@
 package nuextract
 
 import (
-	"bytes"
-	"fmt"
-	"io"
-	"net/http"
-	"os"
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "os"
 )
 
+// Client wraps both NuExtract and OpenAI credentials.
 type Client struct {
-	projectID string
-	apiKey    string
-	http      *http.Client
+    projectID    string
+    nuexAPIKey   string
+    openAIAPIKey string
+    http         *http.Client
 }
 
 func New() *Client {
-	return &Client{
-		projectID: os.Getenv("NUEXTRACT_PROJECT_ID"),
-		apiKey:    os.Getenv("NUEXTRACT_API_KEY"),
-		http:      &http.Client{},
-	}
+    return &Client{
+        projectID:    os.Getenv("NUEXTRACT_PROJECT_ID"),
+        nuexAPIKey:   os.Getenv("NUEXTRACT_API_KEY"),
+        openAIAPIKey: os.Getenv("OPENAI_API_KEY"),
+        http:         &http.Client{},
+    }
 }
 
-// Extract envoie un fichier binaire (PDF) à NuExtract et renvoie la réponse brute.
-func (c *Client) Extract(file []byte) ([]byte, error) {
-	url := fmt.Sprintf("https://nuextract.ai/api/projects/%s/extract", c.projectID)
+// ExtractAndEnrich sends a PDF to NuExtract, then feeds its JSON into your OpenAI Agent
+// via the Responses API, returning the enriched CV JSON.
+func (c *Client) ExtractAndEnrich(file []byte) ([]byte, error) {
+    // 1) Call NuExtract
+    nuexURL := fmt.Sprintf("https://nuextract.ai/api/projects/%s/extract", c.projectID)
+    req, err := http.NewRequest(http.MethodPost, nuexURL, bytes.NewReader(file))
+    if err != nil {
+        return nil, err
+    }
+    req.Header.Set("Authorization", "Bearer "+c.nuexAPIKey)
+    req.Header.Set("Content-Type", "application/octet-stream")
 
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(file))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-	req.Header.Set("Content-Type", "application/octet-stream")
+    resp, err := c.http.Do(req)
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
 
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
+    if resp.StatusCode >= 400 {
+        body, _ := io.ReadAll(resp.Body)
+        return nil, fmt.Errorf("nuextract error %d: %s", resp.StatusCode, body)
+    }
 
-	if resp.StatusCode >= 400 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("nuextract error %d: %s", resp.StatusCode, body)
-	}
-	return io.ReadAll(resp.Body)
+    raw, err := io.ReadAll(resp.Body)
+    if err != nil {
+        return nil, err
+    }
+
+    // 2) Call OpenAI Responses API
+    if c.openAIAPIKey == "" {
+        return nil, fmt.Errorf("OPENAI_API_KEY not set")
+    }
+
+    promptObj := map[string]string{
+        "id":      "pmpt_68930fac64248193b98138eec93c9593095b4a2e570c9476",
+    }
+    payload := map[string]interface{}{
+        "prompt":            promptObj,
+        "input":             string(raw),
+        "max_output_tokens": 50000,
+    }
+    bodyBytes, err := json.Marshal(payload)
+    if err != nil {
+        return nil, err
+    }
+
+    oaReq, err := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", bytes.NewReader(bodyBytes))
+    if err != nil {
+        return nil, err
+    }
+    oaReq.Header.Set("Authorization", "Bearer "+c.openAIAPIKey)
+    oaReq.Header.Set("Content-Type", "application/json")
+
+    oaResp, err := c.http.Do(oaReq)
+    if err != nil {
+        return nil, err
+    }
+    defer oaResp.Body.Close()
+
+    respBytes, _ := io.ReadAll(oaResp.Body)
+    if oaResp.StatusCode >= 400 {
+        return nil, fmt.Errorf("openai error %d: %s", oaResp.StatusCode, respBytes)
+    }
+
+    // 3) Unwrap the assistant's JSON from the response envelope
+    var wrap struct {
+        Output []struct {
+            Content []struct {
+                Text string `json:"text"`
+            } `json:"content"`
+        } `json:"output"`
+    }
+    if err := json.Unmarshal(respBytes, &wrap); err != nil {
+        return nil, err
+    }
+    if len(wrap.Output) == 0 || len(wrap.Output[0].Content) == 0 {
+        return nil, fmt.Errorf("no content in OpenAI response")
+    }
+
+    return []byte(wrap.Output[0].Content[0].Text), nil
 }


### PR DESCRIPTION
Tried to add the LLM step on top of the OCR extract in order to connect both step'

Should work in place as we just refine the "same format" JSON

NB: the prompt that is generating the JSON does not change anything for Nuextract keys, accessible from our project space in Open platform API

**GPT prompt:**

Tu es un agent spécialisé dans l’enrichissement et la valorisation de CV.  
Ta tâche : recevoir en entrée un dictionnaire JSON structuré comme ci-dessous, puis produire en sortie un dictionnaire au **même format**, dont chaque champ aura été « étoffé » ou complété en croisant les données disponibles, en ajoutant des détails chiffrés, des compétences implicites, des définitions, etc.

Entrée (exemple) :
{
  "Profil candidat": {
    "Titre du poste": "verbatim-string",
    "Résumé professionnel": "string",
    "Expérience": integer|null,
    "Disponibilité": "verbatim-string"|null,
    "Langues": {
      "Français": "verbatim-string"|null,
      "Anglais": "verbatim-string"|null,
      "Espagnol": "verbatim-string"|null
    }
  },
  "Experiences": [
    {
      "Poste": "verbatim-string",
      "Entreprise": "verbatim-string",
      "Date de début": "YYYY-MM",
      "Date de fin": "YYYY-MM"|null,
      "Description": "string",
      "Tak skills": ["verbatim-string", …]
    }, …
  ],
  "Compétences techniques": ["verbatim-string", …],
  "Compétences comportementales": ["verbatim-string", …],
  "Certifications": ["verbatim-string", …]
}

**Instructions détaillées** :

1. **Calcul de l’expérience totale**  
   - Si `Profil candidat["Expérience"]` est `null`, calcule la somme des durées (en années et mois) de toutes les `Experiences`.  
2. **Disponibilité**  
   - Si `null`, déduis-la de la date de fin de la dernière expérience ; propose « immédiate » ou « à partir de MM/YYYY ».  
3. **Enrichissement du résumé**  
   - Intègre des mots-clés métiers (ex : “BIM”, “lean construction”), des chiffres (volume de projets, budgets), et des contextes sectoriels (tertiaire, industriel).  
4. **Langues**  
   - Pour chaque langue non nulle, ajoute :  
     - Le niveau CECR (A1–C2) estimé.  
     - Un exemple concret (ex : “Rédaction de rapports”, “réunions internationales”).  
5. **Expériences**  
   - Pour chaque entrée :  
     - Garde les dates au format ISO (`YYYY-MM`).  
     - Dans `Description`, ajoute des indicateurs de performance (délais tenus, économies réalisées…), des outils/méthodologies (MS Project, Lean, ISO), des responsabilités précises.  
     - Remplis `Tak skills` en extrayant 3–5 compétences-tâches issues de la description (ex : “planification détaillée”, “gestion des sous-traitants”, “reporting financier”).  
6. **Compétences techniques & comportementales**  
   - Pour chaque item, ajoute un court **texte explicatif** (1 phrase) et un exemple d’application concrète sur un projet.  
7. **Certifications**  
   - Pour chaque certif’, ajoute :  
     - L’**organisme** certificateur.  
     - L’**année** d’obtention (estimée si manquante).  
     - L’**objectif** ou la portée (ex : “Garantie de conformité QHSE”).  
8. **Format de sortie**  
   - Strictement **JSON**, même structure, sans clés supplémentaires hors celles listées.  
   - Ne pas générer de texte libre en dehors du JSON.
